### PR TITLE
Run both frontend and backend concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "src/backend/server.js",
   "scripts": {
     "start": "node src/backend/server.js",
-    "dev": "nodemon src/backend/server.js",
-    "build": "next build"
+    "dev": "concurrently \"npm run start:frontend\" \"nodemon src/backend/server.js\"",
+    "build": "next build",
+    "start:frontend": "next dev"
   },
   "dependencies": {
     "express": "^4.17.1",
@@ -20,7 +21,8 @@
     "react-dom": "^17.0.2",
     "next": "^10.1.3",
     "tailwindcss": "^2.1.1",
-    "styled-components": "^5.2.3"
+    "styled-components": "^5.2.3",
+    "concurrently": "^6.0.0"
   },
   "keywords": [],
   "author": "",

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -4,6 +4,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
 const firebase = require('firebase');
+const path = require('path');
 const emojiPostsRoutes = require('./routes/emojiPosts');
 const emojiReactionsRoutes = require('./routes/emojiReactions');
 const leaderboardRoutes = require('./routes/leaderboard');
@@ -35,6 +36,13 @@ firebase.initializeApp(firebaseConfig);
 app.use('/api/emojiPosts', emojiPostsRoutes);
 app.use('/api/emojiReactions', emojiReactionsRoutes);
 app.use('/api/leaderboard', leaderboardRoutes);
+
+// Serve frontend
+app.use(express.static(path.join(__dirname, '../../out')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '../../out/index.html'));
+});
 
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);


### PR DESCRIPTION
Add frontend start script and update development script to run both frontend and backend concurrently.

* **package.json**
  - Add a new script `"start:frontend": "next dev"` to start the frontend.
  - Update the `"dev"` script to `"concurrently \"npm run start:frontend\" \"nodemon src/backend/server.js\""` to run both frontend and backend concurrently.
  - Add `concurrently` dependency.

* **src/backend/server.js**
  - Add a new route to serve the frontend using `express.static`.
  - Update the server to serve the frontend on the root URL.

